### PR TITLE
With .NET Core 2.1 release, updated References to stable version

### DIFF
--- a/src/FileCache.Signed/FileCache.Signed.csproj
+++ b/src/FileCache.Signed/FileCache.Signed.csproj
@@ -11,9 +11,8 @@
     <AssemblyOriginatorKeyFile>..\..\fckey.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
 	  <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
-    <UpdateVersionProperties>false</UpdateVersionProperties>
-    <Version>2.1.1</Version>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <UpdateVersionProperties>true</UpdateVersionProperties>
+    <Version>0.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\FileCache\FileCache.cs" Link="FileCache.cs" />
@@ -37,6 +36,6 @@
     <Reference Include="System.Runtime.Caching" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Runtime.Caching" Version="4.5.0-preview2-26406-04" />
+    <PackageReference Include="System.Runtime.Caching" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/src/FileCache.UnitTests/FileCache.UnitTests.csproj
+++ b/src/FileCache.UnitTests/FileCache.UnitTests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
-    <PackageReference Include="FluentAssertions" Version="5.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.1" />
+    <PackageReference Include="FluentAssertions" Version="5.3.2" />
     
   </ItemGroup>
 

--- a/src/FileCache/FileCache.csproj
+++ b/src/FileCache/FileCache.csproj
@@ -8,9 +8,8 @@
     <Authors>Adam Carter</Authors>
     <Description>FileCache is a concrete implementation of the .NET System.Runtime.Caching.ObjectCache that uses the local filesystem as the target location.</Description>
     <Copyright>Copyright (c) 2012, 2013, 2017 Adam Carter (http://adam-carter.com)</Copyright>
-    <UpdateVersionProperties>false</UpdateVersionProperties>
-    <Version>2.1.1</Version>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <UpdateVersionProperties>true</UpdateVersionProperties>
+    <Version>0.0.0</Version>
     <Company>Adam Carter</Company>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net40|AnyCPU'">
@@ -30,6 +29,6 @@
     <Reference Include="System.Runtime.Caching" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Runtime.Caching" Version="4.5.0-preview2-26406-04" />
+    <PackageReference Include="System.Runtime.Caching" Version="4.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
.netcore 2.1 was released today, and so we have the Stable package of System.Runtime.Caching 4.5.

Updated the package. Plus you also notice that I put back the <UpdateVersionProperties> flag to true. This helps ensure that the GitVersionTask (which derives the version from the githistory), can put the proper version into the assembly.