### PR TITLE
Fixed cache collision when name has period.

### DIFF
--- a/src/FileCache.UnitTests/FileCacheTest.cs
+++ b/src/FileCache.UnitTests/FileCacheTest.cs
@@ -47,6 +47,25 @@ namespace FC.UnitTests
         }
 
         [TestMethod]
+        public void CacheNameCollisionTest()
+        {
+            // given
+            _cache = new FileCache();
+            CacheItemPolicy policy =
+                new CacheItemPolicy
+                {
+                    AbsoluteExpiration = (DateTimeOffset) DateTime.Now.AddMinutes(30)
+                };
+
+            // when
+            _cache.Set("test.1", "Red", policy);
+            _cache.Set("test.2", "Blue", policy);
+
+            // then
+            _cache.Get("test.1").Should().Be("Red");
+        }
+
+        [TestMethod]
         public void PolicySaveTest()
         {
             _cache = new FileCache();

--- a/src/FileCache/FileCache.cs
+++ b/src/FileCache/FileCache.cs
@@ -831,7 +831,7 @@ namespace System.Runtime.Caching
                 regionName = "";
             }
             string directory = Path.Combine(CacheDir, _cacheSubFolder, regionName);
-            string filePath = Path.Combine(directory, Path.GetFileNameWithoutExtension(FileName) + ".dat");
+            string filePath = Path.Combine(directory, FileName + ".dat");
             if (!Directory.Exists(directory))
             {
                 Directory.CreateDirectory(directory);


### PR DESCRIPTION
Removed Path.GetFileNameWithoutExtension() from GetCachePath, which as removing any key suffix after a period, treating it like an extension.