### PR TITLE
Another crack at fixing issue #18

### DIFF
--- a/src/FileCache/FileCache.cs
+++ b/src/FileCache/FileCache.cs
@@ -728,15 +728,6 @@ namespace System.Runtime.Caching
                 stream.Close();
             }
 
-            // try to update the last access time
-            try
-            {
-                File.SetLastAccessTime(cachedItemPath, DateTime.Now);
-            }
-            catch (IOException)
-            {
-            }
-
             //check to see if limit was reached
             if(CurrentCacheSize > MaxCacheSize)
             {


### PR DESCRIPTION
File.SetLastAccessTime() seems to be the culprit to occasional unhandled exceptions.  