### PR TITLE
Issue #42 fix

### DIFF
--- a/src/FileCache/FileCache.cs
+++ b/src/FileCache/FileCache.cs
@@ -341,6 +341,14 @@ namespace System.Runtime.Caching
                 _cleanInterval = cleanInterval;
             }
 
+            //set up cache manager
+            CacheManager = FileCacheManagerFactory.Create(manager);
+            CacheManager.CacheDir = CacheDir;
+            CacheManager.CacheSubFolder = _cacheSubFolder;
+            CacheManager.PolicySubFolder = _policySubFolder;
+            CacheManager.Binder = _binder;
+            CacheManager.AccessTimeout = new TimeSpan();
+
             //check to see if cache is in need of immediate cleaning
             if (ShouldClean())
             {
@@ -352,14 +360,6 @@ namespace System.Runtime.Caching
                 // update the cache size, so no need to do it twice.
                 UpdateCacheSizeAsync();
             }
-
-            //set up cache manager
-            CacheManager = FileCacheManagerFactory.Create(manager);
-            CacheManager.CacheDir = CacheDir;
-            CacheManager.CacheSubFolder = _cacheSubFolder;
-            CacheManager.PolicySubFolder = _policySubFolder;
-            CacheManager.Binder = _binder;
-            CacheManager.AccessTimeout = new TimeSpan();
 
             MaxCacheSizeReached += FileCache_MaxCacheSizeReached;
         }


### PR DESCRIPTION
re-arranged the FC constructor so that cleaning check occurs after CacheManager construction (prevents runtime exception, addresses #42)