### PR TITLE
Feature/remove-BinaryFormatter

### DIFF
--- a/src/FileCache.UnitTests/FileCache.UnitTests.csproj
+++ b/src/FileCache.UnitTests/FileCache.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/src/FileCache.UnitTests/FileCache.UnitTests.csproj
+++ b/src/FileCache.UnitTests/FileCache.UnitTests.csproj
@@ -7,13 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp5.0'">
+    <Reference Include="System.Runtime.Caching" />
+  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <Reference Include="System.Runtime.Caching" />
   </ItemGroup>
@@ -28,6 +30,8 @@
     <ProjectReference Include="..\FileCache\FileCache.csproj" />
   </ItemGroup>
 
+  <!-- VisualStudio creates this when it notices a project includes tests. It tells VisualStudio to open the Test Explorer package. -->
+  <!-- Not sure if just VS or also VSCode... -->
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/src/FileCache.UnitTests/FileCache.UnitTests.csproj
+++ b/src/FileCache.UnitTests/FileCache.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/src/FileCache.UnitTests/README.md
+++ b/src/FileCache.UnitTests/README.md
@@ -1,0 +1,49 @@
+Unit-Testing FileCache
+------------------------
+
+This will tell dotnet to build FileCache and run all of the tests.
+
+``` shell
+cd /path/to/FileCache/src/FileCache.UnitTests
+dotnet test FileCache.UnitTests.csproj
+```
+
+Unit-Test Suites
+----------------
+
+There are two test suites:
+
+1. FileCacheTest.cs
+   - These tests use the BasicFileCacheManager when running various unit-tests.
+
+1. HashedFileCache.cs
+   - These tests are similar, but use the HashedFileCacheManager.
+
+
+WSL2 Warning!
+----------------
+
+Sometimes a WSL operating system's time can get out-of-sync with the actual time (see [this](https://github.com/microsoft/WSL/issues/4114)). If it's out of sync enough, some tests can fail if Windows is ultimately in charge of file stats like Last Accessed Time. This happens if your FileCache repo is on a Windows drive (i.e. something under /mnt/c, /mnt/d, etc).
+
+For example, FileCache.FlushRegionTest will fail with this error when your WSL'd Linux OS is 1 minute in the past:
+
+```
+Failed FlushRegionTest [1 s]
+Error Message:
+ Expected result2 to be <null>, but found "Value2".
+Stack Trace:
+   at FluentAssertions.Execution.LateBoundTestFramework.Throw(String message)
+ at FluentAssertions.Execution.TestFrameworkProvider.Throw(String message)
+ at FluentAssertions.Execution.DefaultAssertionStrategy.HandleFailure(String message)
+ at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
+ at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
+ at FluentAssertions.Execution.AssertionScope.FailWith(String message, Object[] args)
+ at FluentAssertions.Primitives.ReferenceTypeAssertions`2.BeNull(String because, Object[] becauseArgs)
+ at FC.UnitTests.FileCacheTest.FlushRegionTest() in /mnt/path/to/FileCache/src/FileCache.UnitTests/FileCacheTest.cs:line 266
+```
+
+To fix, you can try:
+    `sudo hwclock -s`
+
+If that doesn't work, you'll probably have to shutdown and restart the VMs:
+    `wsl --shutdown`

--- a/src/FileCache/BasicFileCacheManager.cs
+++ b/src/FileCache/BasicFileCacheManager.cs
@@ -11,7 +11,7 @@ namespace System.Runtime.Caching
     public class BasicFileCacheManager : FileCacheManager
     {
         /// <summary>
-        /// Returns a list of keys for a given region.  
+        /// Returns a list of keys for a given region.
         /// </summary>
         /// <param name="regionName"></param>
         /// <returns></returns>
@@ -33,7 +33,7 @@ namespace System.Runtime.Caching
         }
 
         /// <summary>
-        /// Builds a string that will place the specified file name within the appropriate 
+        /// Builds a string that will place the specified file name within the appropriate
         /// cache and workspace folder.
         /// </summary>
         /// <param name="FileName"></param>

--- a/src/FileCache/BasicFileCacheManager.cs
+++ b/src/FileCache/BasicFileCacheManager.cs
@@ -74,7 +74,5 @@ namespace System.Runtime.Caching
             }
             return filePath;
         }
-
-
     }
 }

--- a/src/FileCache/FileCache.cs
+++ b/src/FileCache/FileCache.cs
@@ -692,8 +692,9 @@ namespace System.Runtime.Caching
                         string policyPath = CacheManager.GetPolicyPath(key, region);
                         string cachePath = CacheManager.GetCachePath(key, region);
 
-                        // Update the Cache size
+                        // Update the Cache size before flushing this item.
                         CurrentCacheSize = GetCacheSize();
+
                         //if either policy or cache are stale, delete both
                         if (File.GetLastAccessTime(policyPath) < minDate || File.GetLastAccessTime(cachePath) < minDate)
                         {
@@ -706,6 +707,7 @@ namespace System.Runtime.Caching
                 cLock.Close();
             }
         }
+
         /// <summary>
         /// Returns the policy attached to a given cache item.
         /// </summary>

--- a/src/FileCache/FileCache.cs
+++ b/src/FileCache/FileCache.cs
@@ -608,12 +608,14 @@ namespace System.Runtime.Caching
             {
                 size += fi.Length;
             }
+
             // Add subdirectory sizes.
             var dis = root.EnumerateDirectories();
             foreach (DirectoryInfo di in dis)
             {
                 size += CacheSizeHelper(di);
             }
+
             return size;
         }
 
@@ -743,10 +745,9 @@ namespace System.Runtime.Caching
 
             //check to see if limit was reached
             if (CurrentCacheSize > MaxCacheSize)
-                if (CurrentCacheSize > MaxCacheSize)
-                {
-                    MaxCacheSizeReached(this, new FileCacheEventArgs(CurrentCacheSize, MaxCacheSize));
-                }
+            {
+                MaxCacheSizeReached(this, new FileCacheEventArgs(CurrentCacheSize, MaxCacheSize));
+            }
         }
 
         #endregion
@@ -954,7 +955,6 @@ namespace System.Runtime.Caching
         public override object Remove(string key, string regionName = null)
         {
             object valueToDelete = null;
-
 
             if (Contains(key, regionName) == true)
             {

--- a/src/FileCache/FileCache.cs
+++ b/src/FileCache/FileCache.cs
@@ -29,7 +29,7 @@ namespace System.Runtime.Caching
         private const string LastCleanedDateFile = "cache.lcd";
         private const string CacheSizeFile = "cache.size";
         // this is a file used to prevent multiple processes from trying to "clean" at the same time
-        private const string SemaphoreFile = "cache.sem"; 
+        private const string SemaphoreFile = "cache.sem";
         private long _currentCacheSize = 0;
         private PayloadMode _readMode = PayloadMode.Serializable;
         public string CacheDir { get; protected set; }
@@ -52,7 +52,7 @@ namespace System.Runtime.Caching
 
         /// <summary>
         /// Used to abstract away the low-level details of file management.  This allows
-        /// for multiple file formatting schemes based on use case.  
+        /// for multiple file formatting schemes based on use case.
         /// </summary>
         public FileCacheManager CacheManager { get; protected set; }
 
@@ -112,7 +112,7 @@ namespace System.Runtime.Caching
         public TimeSpan FilenameAsPayloadSafetyMargin = TimeSpan.FromMinutes(10);
 
         /// <summary>
-        /// Used to determine how long the FileCache will wait for a file to become 
+        /// Used to determine how long the FileCache will wait for a file to become
         /// available.  Default (00:00:00) is indefinite.  Should the timeout be
         /// reached, an exception will be thrown.
         /// </summary>
@@ -136,7 +136,7 @@ namespace System.Runtime.Caching
         /// <summary>
         /// Returns the approximate size of the file cache
         /// </summary>
-        public long CurrentCacheSize 
+        public long CurrentCacheSize
         {
             get
             {
@@ -163,7 +163,7 @@ namespace System.Runtime.Caching
                     CacheManager.WriteSysFile(CacheSizeFile, value);
                     _currentCacheSize = value;
                 }
-            } 
+            }
         }
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace System.Runtime.Caching
         /// </summary>
         public event EventHandler<FileCacheEventArgs> MaxCacheSizeReached = delegate { };
 
-        public event EventHandler<FileCacheEventArgs> CacheResized = delegate { }; 
+        public event EventHandler<FileCacheEventArgs> CacheResized = delegate { };
 
         /// <summary>
         /// The default cache path used by FC.
@@ -311,10 +311,10 @@ namespace System.Runtime.Caching
             bool setCacheDirToDefault = true,
             bool setBinderToDefault = true
             )
-        {   
+        {
             _name = "FileCache_" + _nameCounter;
             _nameCounter++;
-            
+
             DefaultRegion = null;
             DefaultPolicy = new CacheItemPolicy();
             MaxCacheSize = long.MaxValue;
@@ -337,7 +337,7 @@ namespace System.Runtime.Caching
 
             // only set the clean interval if the user supplied it
             if (cleanInterval > new TimeSpan())
-            { 
+            {
                 _cleanInterval = cleanInterval;
             }
 
@@ -356,7 +356,7 @@ namespace System.Runtime.Caching
             }
             else if (calculateCacheSize || CurrentCacheSize == 0)
             {
-                // This is in an else if block, because CleanCacheAsync will 
+                // This is in an else if block, because CleanCacheAsync will
                 // update the cache size, so no need to do it twice.
                 UpdateCacheSizeAsync();
             }
@@ -422,7 +422,7 @@ namespace System.Runtime.Caching
         public long ShrinkCacheToSize(long newSize, string regionName = null)
         {
             long originalSize = 0, amount = 0, removed = 0;
-            
+
             //lock down other treads from trying to shrink or clean
             using (FileStream cLock = GetCleaningLock())
             {
@@ -480,7 +480,7 @@ namespace System.Runtime.Caching
         public long CleanCache(string regionName = null)
         {
             long removed = 0;
-            
+
             //lock down other treads from trying to shrink or clean
             using (FileStream cLock = GetCleaningLock())
             {
@@ -529,10 +529,10 @@ namespace System.Runtime.Caching
         /// </summary>
         /// <returns>The amount of data that was actually removed</returns>
         private long DeleteOldestFiles(long amount, string regionName = null)
-        { 
+        {
             // Verify that we actually need to shrink
             if (amount <= 0)
-            { 
+            {
                 return 0;
             }
 
@@ -576,7 +576,7 @@ namespace System.Runtime.Caching
         }
 
         /// <summary>
-        /// This method calls GetCacheSize on a separate thread to 
+        /// This method calls GetCacheSize on a separate thread to
         /// calculate and then store the size of the cache.
         /// </summary>
         public void UpdateCacheSizeAsync()
@@ -717,7 +717,7 @@ namespace System.Runtime.Caching
             }
         }
         /// <summary>
-        /// Returns the policy attached to a given cache item.  
+        /// Returns the policy attached to a given cache item.
         /// </summary>
         /// <param name="key">The key of the item</param>
         /// <param name="regionName">The region in which the key exists</param>
@@ -837,7 +837,7 @@ namespace System.Runtime.Caching
                     ;
             }
         }
-        
+
         public override object Get(string key, string regionName = null)
         {
             FileCachePayload payload = CacheManager.ReadFile(PayloadReadMode, key, regionName) as FileCachePayload;
@@ -861,7 +861,7 @@ namespace System.Runtime.Caching
                     //delete the file from the cache
                     try
                     {
-                        // CT Note: I changed this to Remove from File.Delete so that the coresponding 
+                        // CT Note: I changed this to Remove from File.Delete so that the coresponding
                         // policy file will be deleted as well, and CurrentCacheSize will be updated.
                         Remove(key, regionName);
                     }
@@ -877,7 +877,7 @@ namespace System.Runtime.Caching
                         payload.Policy.AbsoluteExpiration = DateTime.Now.Add(payload.Policy.SlidingExpiration);
                         WriteHelper(PayloadWriteMode, key, payload, regionName, true);
                     }
-                    
+
                 }
             }
             else
@@ -967,7 +967,7 @@ namespace System.Runtime.Caching
         {
             object valueToDelete = null;
 
-            
+
             if (Contains(key, regionName) == true)
             {
 
@@ -993,7 +993,7 @@ namespace System.Runtime.Caching
                 catch (IOException)
                 {
                 }
-                
+
             }
             return valueToDelete;
         }
@@ -1044,7 +1044,7 @@ namespace System.Runtime.Caching
             }
         }
 
-        // CT: This private class is used to help shrink the cache. 
+        // CT: This private class is used to help shrink the cache.
         // It computes the total size of an entry including it's policy file.
         // It also implements IComparable functionality to allow for sorting based on access time
         private class CacheItemReference : IComparable<CacheItemReference>

--- a/src/FileCache/FileCache.csproj
+++ b/src/FileCache/FileCache.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net45;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
-	  <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>cache objectcache System.Runtime.Caching.ObjectCache</PackageTags>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Authors>Adam Carter</Authors>
@@ -28,12 +28,12 @@
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
-    <PackageReference Include="GitVersionTask" Version="5.3.2">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
+  <!-- <ItemGroup> -->
+  <!--   <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" /> -->
+  <!--   <PackageReference Include="GitVersionTask" Version="5.3.2"> -->
+  <!--     <PrivateAssets>All</PrivateAssets> -->
+  <!--   </PackageReference> -->
+  <!-- </ItemGroup> -->
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System.Runtime.Caching" />

--- a/src/FileCache/FileCacheManager.cs
+++ b/src/FileCache/FileCacheManager.cs
@@ -489,6 +489,18 @@ namespace System.Runtime.Caching
         }
 
         /// <summary>
+        /// Writes a long to a system file that is not part of the cache itself,
+        /// but is used to help it function.
+        /// </summary>
+        /// <param name="filename">The name of the sysfile (without directory)</param>
+        /// <param name="data">The DateTime to write to the file</param>
+        public void WriteSysValue(string filename, DateTime data)
+        {
+            // Convert to long and use long's function.
+            WriteSysValue(filename, data.ToBinary());
+        }
+
+        /// <summary>
         /// This function servies to centralize file stream access within this class.
         /// </summary>
         /// <param name="path"></param>

--- a/src/FileCache/FileCacheManager.cs
+++ b/src/FileCache/FileCacheManager.cs
@@ -18,7 +18,7 @@ namespace System.Runtime.Caching
         public SerializationBinder Binder { get; set; }
 
         /// <summary>
-        /// Used to determine how long the FileCache will wait for a file to become 
+        /// Used to determine how long the FileCache will wait for a file to become
         /// available.  Default (00:00:00) is indefinite.  Should the timeout be
         /// reached, an exception will be thrown.
         /// </summary>
@@ -219,16 +219,16 @@ namespace System.Runtime.Caching
         }
 
         /// <summary>
-        /// Builds a string that will place the specified file name within the appropriate 
+        /// Builds a string that will place the specified file name within the appropriate
         /// cache and workspace folder.
         /// </summary>
         /// <param name="key"></param>
         /// <param name="regionName"></param>
         /// <returns></returns>
         public abstract string GetCachePath(string key, string regionName = null);
-        
+
         /// <summary>
-        /// Returns a list of keys for a given region.  
+        /// Returns a list of keys for a given region.
         /// </summary>
         /// <param name="regionName"></param>
         /// <returns></returns>
@@ -262,7 +262,7 @@ namespace System.Runtime.Caching
 
         /// <summary>
         /// Reads data in from a system file. System files are not part of the
-        /// cache itself, but serve as a way for the cache to store data it 
+        /// cache itself, but serve as a way for the cache to store data it
         /// needs to operate.
         /// </summary>
         /// <param name="filename">The name of the sysfile (without directory)</param>
@@ -390,7 +390,7 @@ namespace System.Runtime.Caching
             }
             catch (IOException ex)
             {
-                //Owning FC might be interested in this exception.  
+                //Owning FC might be interested in this exception.
                 throw ex;
             }
             return Math.Abs(bytesFreed);

--- a/src/FileCache/FileCacheManager.cs
+++ b/src/FileCache/FileCacheManager.cs
@@ -284,11 +284,11 @@ namespace System.Runtime.Caching
                 using (BinaryWriter writer = new BinaryWriter(stream))
                 {
                     data.Policy.Serialize(writer);
-
-                    // adjust cache size
-                    cacheSizeDelta += new FileInfo(cachedPolicy).Length;
                 }
             }
+
+            // Adjust cache size outside of the using blocks to ensure it's after the data is written.
+            cacheSizeDelta += new FileInfo(cachedPolicy).Length;
 
             return cacheSizeDelta;
         }

--- a/src/FileCache/HashedFileCacheManager.cs
+++ b/src/FileCache/HashedFileCacheManager.cs
@@ -85,7 +85,7 @@ namespace System.Runtime.Caching
         }
 
         /// <summary>
-        /// Builds a string that will place the specified file name within the appropriate 
+        /// Builds a string that will place the specified file name within the appropriate
         /// cache and workspace folder.
         /// </summary>
         /// <param name="key"></param>
@@ -106,7 +106,7 @@ namespace System.Runtime.Caching
         }
 
         /// <summary>
-        /// Returns a list of keys for a given region.  
+        /// Returns a list of keys for a given region.
         /// </summary>
         /// <param name="regionName"></param>
         public override IEnumerable<string> GetKeys(string regionName = null)

--- a/src/FileCache/HashedFileCacheManager.cs
+++ b/src/FileCache/HashedFileCacheManager.cs
@@ -12,6 +12,7 @@ namespace System.Runtime.Caching
     public class HashedFileCacheManager : FileCacheManager
     {
         private static IxxHash _hasher = xxHashFactory.Instance.Create();
+
         /// <summary>
         /// Returns a 64bit hash in hex of supplied key
         /// </summary>
@@ -54,7 +55,7 @@ namespace System.Runtime.Caching
                     //check for correct key
                     try
                     {
-                        SerializableCacheItemPolicy policy = Deserialize(fileName) as SerializableCacheItemPolicy;
+                        SerializableCacheItemPolicy policy = DeserializePolicyData(fileName);
                         if (key.CompareTo(policy.Key) == 0)
                         {
                             //correct key found!
@@ -124,7 +125,7 @@ namespace System.Runtime.Caching
                 {
                     try
                     {
-                        SerializableCacheItemPolicy policy = Deserialize(file) as SerializableCacheItemPolicy;
+                        SerializableCacheItemPolicy policy = DeserializePolicyData(file);
                         keys.Add(policy.Key);
                     }
                     catch

--- a/src/FileCache/PriortyQueue.cs
+++ b/src/FileCache/PriortyQueue.cs
@@ -23,8 +23,8 @@ namespace System.Runtime.Caching
         /// <summary>
         /// Default constructor.
         /// </summary>
-        /// <param name="comparer">The comparer to use.  The default comparer will make the smallest item the root of the heap.  
-        /// 
+        /// <param name="comparer">The comparer to use.  The default comparer will make the smallest item the root of the heap.
+        ///
         /// </param>
         public PriortyQueue(IComparer<T> comparer = null)
         {

--- a/src/FileCache/SerializableCacheItemPolicy.cs
+++ b/src/FileCache/SerializableCacheItemPolicy.cs
@@ -66,7 +66,7 @@ namespace System.Runtime.Caching
         {
             writer.Write(CACHE_VERSION);
 
-            writer.Write(AbsoluteExpiration.Date.ToBinary());
+            writer.Write(AbsoluteExpiration.DateTime.ToBinary());
             writer.Write(AbsoluteExpiration.Offset.TotalMilliseconds);
 
             writer.Write(SlidingExpiration.TotalMilliseconds);
@@ -100,7 +100,8 @@ namespace System.Runtime.Caching
                 return new SerializableCacheItemPolicy {
                     AbsoluteExpiration = new DateTimeOffset(DateTime.FromBinary(reader.ReadInt64()),
                                                             TimeSpan.FromMilliseconds(reader.ReadDouble())),
-                    SlidingExpiration = TimeSpan.FromMilliseconds(reader.ReadDouble()),
+                    // Don't clobber absolute by using sliding's setter; set the private value instead.
+                    _slidingExpiration = TimeSpan.FromMilliseconds(reader.ReadDouble()),
                     Key = reader.ReadString(),
                 };
             }


### PR DESCRIPTION
BinaryFormatter is a security issue in .NET 5.0 - this replaces it in most places.

https://docs.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide

BinaryFormatter is replaced with BinaryReader/BinaryWriter for:
  - sysfiles
  - policies
  - ReadFile w/ PayloadMode.RawBytes 
  - WriteFile w/ PayloadMode.RawBytes

Cache files that use BinaryReader/BinaryWriter have a "magic" header number that is checked for in order to make the transition from 3.2.0 to this patch without needing to delete your file cache. The old files will just fail the new header check and the sysfile/policy/etc will continue on as if it were a failed read/missing file.

BinaryFormatter remains for:
  - ReadFile w/ PayloadMode.Serialize
  - WriteFile w/ PayloadMode.Serialize

Those would need to be serialized some other way that wasn't needed for our use case.
  - You could look into adding ZeroFormatter as a dependency: 
    - https://neuecc.medium.com/zeroformatter-fastest-c-serializer-and-infinitely-fast-deserializer-for-net-88e752803fe9
    - https://github.com/neuecc/ZeroFormatter/
    - https://www.nuget.org/packages/ZeroFormatter
  - Or possibly using an XML/JSON formatter instead:
    - https://docs.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide#preferred-alternatives

This pull request partially addresses: https://github.com/acarteas/FileCache/issues/49
