### PR TITLE
Implement encryption serializable payload

### DIFF
--- a/src/FileCache/FileCache.cs
+++ b/src/FileCache/FileCache.cs
@@ -341,7 +341,6 @@ namespace System.Runtime.Caching
             CacheManager.PolicySubFolder = _policySubFolder;
             CacheManager.Binder = _binder;
             CacheManager.AccessTimeout = new TimeSpan();
-            //CacheManager.CryptoKey = cryptoKey;
 
             //check to see if cache is in need of immediate cleaning
             if (ShouldClean())

--- a/src/FileCache/FileCache.cs
+++ b/src/FileCache/FileCache.cs
@@ -81,7 +81,11 @@ namespace System.Runtime.Caching
             /// <summary>
             /// Treat the paylad as raw bytes. A byte[] and readable streams are supported on add.
             /// </summary>
-            RawBytes
+            RawBytes,
+            /// <summary>
+            /// Treat the payload as a crypto serializable object.
+            /// </summary>
+            CryptoSerializable,
         }
 
         /// <summary>
@@ -337,6 +341,7 @@ namespace System.Runtime.Caching
             CacheManager.PolicySubFolder = _policySubFolder;
             CacheManager.Binder = _binder;
             CacheManager.AccessTimeout = new TimeSpan();
+            //CacheManager.CryptoKey = cryptoKey;
 
             //check to see if cache is in need of immediate cleaning
             if (ShouldClean())


### PR DESCRIPTION
I have written a extension to encrypt the payload on writing to storage. That will be more security to protect the data. So far the results look good in my use case. 

```C#
FileCache simpleCache = new FileCache();
simpleCache.CacheManager.CryptoKey = "SECRET KEY";
simpleCache.PayloadReadMode = FileCache.PayloadMode.CryptoSerializable;
simpleCache.PayloadWriteMode = FileCache.PayloadMode.CryptoSerializable;
```